### PR TITLE
Fix for can't subscript a scaler error

### DIFF
--- a/src/hyperfit/linfit.py
+++ b/src/hyperfit/linfit.py
@@ -315,7 +315,7 @@ class LinFit(object):
         self.norm_scat = self.bessel_cochran(self.norm_scat)
         self.coords, self.vert_scat = self.compute_cartesian()
 
-        return self.coords, self.vert_scat, -result["fun"][0]
+        return self.coords, self.vert_scat, -np.atleast_1d(result["fun"])[0]
 
     # A routine run a zeus MCMC on the model given the data
     def zeus(self, bounds, max_iter=100000, batchsize=1000, ntau=10.0, tautol=0.05, verbose=False):


### PR DESCRIPTION
I have been using hyperfit and have recently started seeing the error given below.  The issue seems to be that `result["fun"]` can be returned as a single element array or a scaler.  Both look to have valid values.  By making this minor change, my fits are now working.  Am still running tests to make sure everything looks good.  But putting in this PR before I forget.

```
    mcmc_samples, mcmc_lnlike = hf_fit.emcee(bounds, verbose=False)
  File "/home/kgordon/Bin/miniconda3/lib/python3.8/site-packages/hyperfit/linfit.py", line 456, in emcee
    self.optimize(bounds, verbose=verbose)
  File "/home/kgordon/Bin/miniconda3/lib/python3.8/site-packages/hyperfit/linfit.py", line 319, in optimize
  return self.coords, self.vert_scat, -result["fun"][0]
IndexError: invalid index to scalar variable.
```